### PR TITLE
feat(binary)!: if empty versioncmd is provided, skip version check

### DIFF
--- a/binary/binary.go
+++ b/binary/binary.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+const SkipVersionCheck = ""
+
 type Binary struct {
 	command   string
 	directory string
@@ -83,6 +85,10 @@ func (b *Binary) isInstalled() bool {
 func (b *Binary) isExpectedVersion() bool {
 	if b.version == "latest" {
 		return true
+	}
+
+	if b.versioncmd == SkipVersionCheck {
+		return false
 	}
 
 	args := strings.Split(b.versioncmd, " ")

--- a/binary/options.go
+++ b/binary/options.go
@@ -34,8 +34,20 @@ func WithGOARCHMapping(mapping map[string]string) Option {
 	}
 }
 
+// WithVersionCmd allows customizing the command that is run to check the
+// version of the binary. The format string should contain a single `%s`
+// placeholder that will be replaced with the binary's command name.
+//
+// This is useful for binaries that don't support the `--version` flag.
+//
+// If the format string is SkipVersionCheck, the version check will be disabled.
 func WithVersionCmd(format string) Option {
 	return func(b *Binary) {
+		if format == SkipVersionCheck {
+			b.versioncmd = SkipVersionCheck
+			return
+		}
+
 		b.versioncmd = fmt.Sprintf(format, b.command)
 	}
 }


### PR DESCRIPTION
This is useful e.g. in case of goimports, stringer, which do not offer a standard way to get version. The check always fails and produces unnecessary output.