### PR TITLE
chore(binary): only check for the semver part of version

### DIFF
--- a/binary/binary.go
+++ b/binary/binary.go
@@ -91,12 +91,14 @@ func (b *Binary) isExpectedVersion() bool {
 		return false
 	}
 
+	semver := strings.TrimPrefix(b.version, "v")
 	args := strings.Split(b.versioncmd, " ")
-	logstep(fmt.Sprintf("running %v looking for %s", args, b.version))
+
+	logstep(fmt.Sprintf("running %v looking for %s", args, semver))
 	out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
 	if err != nil {
 		return false
 	}
 
-	return bytes.Contains(out, []byte(b.version))
+	return bytes.Contains(out, []byte(semver))
 }


### PR DESCRIPTION
Some binaries announce their semver without the v prefix.

Alter the isExpectedVersion check to be less restrictive,
and check only for the semver portion of the version, in case
it was provided with a prefixed letter v.