### PR TITLE
chore(commons): extend GoImports with GoImportsOpts

### DIFF
--- a/commons/goimports.go
+++ b/commons/goimports.go
@@ -10,11 +10,19 @@ import (
 
 // GoImports formats code sorting imports taking in account the
 // local package supplied as argument.
-func GoImports(localpkg string) harness.Task {
+func GoImports(localpkg string, opts ...GoImportsOpt) harness.Task {
+	conf := goimportsconf{
+		version: "latest",
+	}
+
+	for _, opt := range opts {
+		opt(&conf)
+	}
+
 	return func(ctx context.Context) error {
 		imp, _ := bintool.NewGo(
 			"golang.org/x/tools/cmd/goimports",
-			"latest",
+			conf.version,
 		)
 
 		if err := imp.Ensure(); err != nil {
@@ -22,5 +30,19 @@ func GoImports(localpkg string) harness.Task {
 		}
 
 		return harness.Run(ctx, imp.BinPath(), harness.WithArgs("-w", "-local", localpkg, "."))
+	}
+}
+
+type goimportsconf struct {
+	version string
+}
+
+type GoImportsOpt func(c *goimportsconf)
+
+// WithGoImportsVersion allows specifying the goimports version
+// that should be used when running this task.
+func WithGoImportsVersion(version string) GoImportsOpt {
+	return func(c *goimportsconf) {
+		c.version = version
 	}
 }


### PR DESCRIPTION
Similar to golangci-lint implementation, we should support changing the default behavior of goimports by providing a GoImportsOpts struct.

Start with default (latest) version override.