### PR TITLE
chore(binary): support windows executables

### DIFF
--- a/binary/binary.go
+++ b/binary/binary.go
@@ -31,6 +31,10 @@ func New(command, version string, origin Origin, options ...Option) (*Binary, er
 	binDir := filepath.FromSlash("./bin")
 	cmdFullPath := filepath.Join(binDir, command)
 
+	if runtime.GOOS == "windows" {
+		cmdFullPath += ".exe"
+	}
+
 	bin := Binary{
 		commandFullPath: cmdFullPath,
 		directory:       binDir,

--- a/binary/template.go
+++ b/binary/template.go
@@ -13,7 +13,6 @@ type Template struct {
 	Name      string
 	Cmd       string
 	Version   string
-	Extension string
 }
 
 func (t Template) Resolve(format string) (string, error) {


### PR DESCRIPTION
Append .exe to command if the package was used on windows.

Remove Extension from template, because it currently isn't used and I couldn't figure out a good use-case
for it at this point in time.