### PR TITLE
fix(binary): revert removal of Extension from template

### DIFF
--- a/binary/binary.go
+++ b/binary/binary.go
@@ -28,12 +28,13 @@ func New(command, version string, origin Origin, options ...Option) (*Binary, er
 		return nil, fmt.Errorf("version must be set")
 	}
 
-	binDir := filepath.FromSlash("./bin")
-	cmdFullPath := filepath.Join(binDir, command)
-
+	var extension string
 	if runtime.GOOS == "windows" {
-		cmdFullPath += ".exe"
+		extension = ".exe"
 	}
+
+	binDir := filepath.FromSlash("./bin")
+	cmdFullPath := filepath.Join(binDir, command) + extension
 
 	bin := Binary{
 		commandFullPath: cmdFullPath,
@@ -53,6 +54,7 @@ func New(command, version string, origin Origin, options ...Option) (*Binary, er
 		Name:      command,
 		Cmd:       bin.commandFullPath,
 		Version:   bin.version,
+		Extension: extension,
 	}
 
 	for _, opt := range options {

--- a/binary/template.go
+++ b/binary/template.go
@@ -13,6 +13,7 @@ type Template struct {
 	Name      string
 	Cmd       string
 	Version   string
+	Extension string
 }
 
 func (t Template) Resolve(format string) (string, error) {


### PR DESCRIPTION
We need to give the caller the ability to add {{.Extension}} template variable to a remote url. There are binaries distributed with extensions.