### PR TITLE
feat(binary): allow templating binaries mapping when extracting archives

### DIFF
--- a/binary/template.go
+++ b/binary/template.go
@@ -41,3 +41,13 @@ func (t Template) Resolve(format string) (string, error) {
 
 	return bld.String(), nil
 }
+
+// Resolve executes the provided format string as a template with the Template's fields.
+// Panics if the template can't be resolved correctly.
+func (t Template) MustResolve(format string) string {
+	resolved, err := t.Resolve(format)
+	if err != nil {
+		panic(err)
+	}
+	return resolved
+}


### PR DESCRIPTION
because in all their wisdom, some software is compressed with dynamic filenames inside, for example
* grafana has a `grafana-v{version}` folder inside
* alloy has a single binary inside but it's called `alloy-{os}-{arch}`

usage will be like
```go
grafana, _ := binary.New(
	"grafana", "12.0.0",
	binary.RemoteArchiveDownload(
		"https://dl.grafana.com/oss/release/grafana-{{.Version}}.{{.GOOS}}-{{.GOARCH}}.tar.gz",
		map[string]string{
			"grafana-v{{.Version}}/bin/grafana: "grafana",
		},
	),
)
```