### PR TITLE
feat: bin provisioning common

### DIFF
--- a/binary/binary.go
+++ b/binary/binary.go
@@ -31,11 +31,7 @@ type Binary struct {
 // New instantiates a new [Binary] given a command name, a version and it's [Origin].
 // Origins determine where the binary is provisioned from, if it needs installation and how
 // the installation process is handled.
-func New(command, version string, origin Origin, options ...Option) (*Binary, error) {
-	if version == "" {
-		return nil, fmt.Errorf("version must be set")
-	}
-
+func New(command, version string, origin Origin, options ...Option) *Binary {
 	var extension string
 	if runtime.GOOS == "windows" {
 		extension = ".exe"
@@ -69,7 +65,12 @@ func New(command, version string, origin Origin, options ...Option) (*Binary, er
 		opt(&bin)
 	}
 
-	return &bin, nil
+	return &bin
+}
+
+// Name returns the command name of the binary.
+func (b *Binary) Name() string {
+	return b.template.Name
 }
 
 // BinPath returns the qualified path to the binary.
@@ -80,9 +81,14 @@ func (b *Binary) BinPath() string {
 
 // Ensure the binary is installed and it corresponds to the expected version.
 func (b *Binary) Ensure() error {
+	if b.version == "" {
+		return fmt.Errorf("version must be set")
+	}
+
 	if b.isInstalled() && b.isExpectedVersion() {
 		return nil
 	}
+
 	return b.Install()
 }
 

--- a/binary/extract.go
+++ b/binary/extract.go
@@ -1,0 +1,111 @@
+package binary
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// handles .tar.gz files
+func untar(file io.Reader, destination string, processor func(path string) *string) error {
+	decompressor, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer decompressor.Close()
+
+	reader := tar.NewReader(decompressor)
+
+	for {
+		header, err := reader.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+
+		processed := processor(header.Name)
+		if processed == nil {
+			continue
+		}
+		target := filepath.Join(destination, *processed)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", target, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(target), err)
+			}
+
+			out, err := os.Create(target)
+			if err != nil {
+				return fmt.Errorf("failed to create file %s: %w", target, err)
+			}
+			defer out.Close()
+
+			_ = os.Chmod(target, 0o755)
+
+			if _, err := io.Copy(out, reader); err != nil {
+				return fmt.Errorf("failed to copy data to file %s: %w", target, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// handles .zip files
+func unzip(file io.ReaderAt, size int64, destination string, processor func(path string) *string) error {
+	reader, err := zip.NewReader(file, size)
+	if err != nil {
+		return fmt.Errorf("failed to create zip reader: %w", err)
+	}
+
+	for _, file := range reader.File {
+		processed := processor(file.Name)
+		if processed == nil {
+			continue
+		}
+		target := filepath.Join(destination, *processed)
+
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", target, err)
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(target), err)
+		}
+
+		out, err := os.Create(target)
+		if err != nil {
+			return fmt.Errorf("failed to create file %s: %w", target, err)
+		}
+		defer out.Close()
+
+		_ = os.Chmod(target, 0o755)
+
+		contents, err := file.Open()
+		if err != nil {
+			return fmt.Errorf("failed to open file %s: %w", target, err)
+		}
+		defer contents.Close()
+
+		if _, err := io.Copy(out, contents); err != nil {
+			return fmt.Errorf("failed to copy data to file %s: %w", target, err)
+		}
+	}
+
+	return nil
+}

--- a/binary/origin.go
+++ b/binary/origin.go
@@ -140,7 +140,7 @@ func (r *remotearchive) Install(template Template) error {
 
 			// otherwise only extract files that are present in the map
 			if replacement, ok := mapping[path]; ok {
-				logdetail(fmt.Sprintf("resolved %s to %s", path, replacement))
+				logdetail(fmt.Sprintf("  resolved %s to %s", path, replacement))
 				return &replacement
 			}
 			return nil
@@ -190,16 +190,16 @@ func (o *gopkg) Install(template Template) error {
 // download downloads a file from a URL to a local destination.
 // If the destination file already exists, the download is skipped.
 func download(url, destination string) (err error) {
-	logstep(fmt.Sprintf("downloading %s to %s", url, destination))
+	logdetail(fmt.Sprintf("downloading %s to %s", url, destination))
 
 	start := time.Now()
 	defer func() {
 		elapsed := time.Since(start).Round(time.Millisecond)
 		if err != nil {
-			color.Red("   ✘ %s", elapsed)
+			color.Red("     ✘ %s", elapsed)
 			return
 		}
-		color.Green("   ✔ %s", elapsed)
+		color.Green("     ✔ %s", elapsed)
 	}()
 
 	if _, err := os.Stat(destination); err == nil {
@@ -233,16 +233,16 @@ func download(url, destination string) (err error) {
 // Files are extracted with executable permissions (0755).
 // The source archive is removed after successful extraction.
 func extract(compressed, destination string, processor func(path string) *string) (err error) {
-	logstep(fmt.Sprintf("extracting %s", compressed))
+	logdetail(fmt.Sprintf("extracting %s", compressed))
 
 	start := time.Now()
 	defer func() {
 		elapsed := time.Since(start).Round(time.Millisecond)
 		if err != nil {
-			color.Red("   ✘ %s", elapsed)
+			color.Red("     ✘ %s", elapsed)
 			return
 		}
-		color.Green("   ✔ %s", elapsed)
+		color.Green("     ✔ %s", elapsed)
 	}()
 
 	file, err := os.Open(compressed)

--- a/commons/commitsar.go
+++ b/commons/commitsar.go
@@ -24,7 +24,7 @@ func Commitsar(opts ...CommitsarOpt) harness.Task {
 	return func(ctx context.Context) error {
 		// commitsar can't be used with NewGo at the moment, as it's version reporting is messed up and
 		// it will always attempt to download the specified version
-		cmsr, _ := binary.New(
+		cmsr := binary.New(
 			"commitsar",
 			conf.version,
 			binary.RemoteArchiveDownload(

--- a/commons/goimports.go
+++ b/commons/goimports.go
@@ -20,7 +20,7 @@ func GoImports(localpkg string, opts ...GoImportsOpt) harness.Task {
 	}
 
 	return func(ctx context.Context) error {
-		imp, _ := binary.New(
+		imp := binary.New(
 			"goimports",
 			conf.version,
 			binary.GoBinary(

--- a/commons/golangcilint.go
+++ b/commons/golangcilint.go
@@ -26,7 +26,7 @@ func GolangCILint(opts ...GolangCILintOpt) harness.Task {
 	}
 
 	return func(ctx context.Context) error {
-		gci, _ := binary.New(
+		gci := binary.New(
 			"golangci-lint",
 			conf.version,
 			binary.GoBinary("github.com/golangci/golangci-lint/cmd/golangci-lint"),

--- a/commons/gotest.go
+++ b/commons/gotest.go
@@ -114,7 +114,7 @@ func GoIntegrationTest(opts ...TestOpt) harness.Task {
 
 func gotestfmt(ctx context.Context, testout []byte) error {
 	fmt.Println("gotestfmt")
-	gtf, _ := binary.New(
+	gtf := binary.New(
 		"gotestfmt",
 		"latest",
 		binary.GoBinary("github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt"),
@@ -130,7 +130,7 @@ func gotestfmt(ctx context.Context, testout []byte) error {
 // tools like gitlab.
 // https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html
 func computeJunit(ctx context.Context, testout []byte, junitfile string) error {
-	gts, _ := binary.New(
+	gts := binary.New(
 		"gotestsum",
 		"latest",
 		binary.GoBinary("gotest.tools/gotestsum"),
@@ -158,7 +158,7 @@ func computeJunit(ctx context.Context, testout []byte, junitfile string) error {
 // and ingested by tools like gitlab.
 // https://docs.gitlab.com/ee/ci/testing/test_coverage_visualization.html
 func computeCobertura(ctx context.Context, coverfile, coberturafile string) error {
-	cbrt, _ := binary.New(
+	cbrt := binary.New(
 		"gocover-cobertura",
 		"latest",
 		binary.GoBinary("github.com/boumenot/gocover-cobertura"),
@@ -193,7 +193,7 @@ func computeCobertura(ctx context.Context, coverfile, coberturafile string) erro
 // from the coverage calculation.
 // https://github.com/dave/courtney
 func computeCourtneyCoverage(ctx context.Context, coverfile string) error {
-	ctny, _ := binary.New(
+	ctny := binary.New(
 		"courtney",
 		"latest",
 		binary.GoBinary("github.com/dave/courtney"),

--- a/commons/provision.go
+++ b/commons/provision.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
+
 	"github.com/aexvir/harness"
 	"github.com/aexvir/harness/binary"
-	"github.com/fatih/color"
 )
 
 // Provision a list of binaries.

--- a/commons/provision.go
+++ b/commons/provision.go
@@ -1,0 +1,51 @@
+package commons
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aexvir/harness"
+	"github.com/aexvir/harness/binary"
+	"github.com/fatih/color"
+)
+
+// Provision a list of binaries.
+// Generates and executes a list of tasks where [Binary.Ensure] is called on each binary
+// collecting and returning any errors encountered.
+func Provision(binaries ...*binary.Binary) harness.Task {
+	return func(ctx context.Context) (err error) {
+		var errs []string
+		start := time.Now()
+		defer func() {
+			elapsed := time.Since(start).Round(time.Millisecond)
+			if err != nil {
+				color.Red(" ✘ %s\n\n", elapsed)
+				return
+			}
+			color.Green(" ✔ %s\n\n", elapsed)
+		}()
+
+		names := make([]string, 0, len(binaries))
+		for _, bin := range binaries {
+			names = append(names, bin.Name())
+		}
+		harness.LogStep(fmt.Sprintf("provisioning %d binaries: %s", len(binaries), strings.Join(names, ", ")))
+
+		for _, bin := range binaries {
+			if err := bin.Ensure(); err != nil {
+				errs = append(errs, fmt.Sprintf("failed to provision %s: %s", bin.Name(), err))
+			}
+		}
+
+		if len(errs) > 0 {
+			for _, errmsg := range errs {
+				color.Red(" • %s", errmsg)
+			}
+			return fmt.Errorf("provisioning failed")
+		}
+
+		return nil
+	}
+}

--- a/harness.go
+++ b/harness.go
@@ -70,6 +70,17 @@ func (h *Harness) Execute(ctx context.Context, tasks ...Task) error {
 	return nil
 }
 
+// Logs the name of a task step.
+// Harness.Run automatically uses this function to print what is running,
+// this is mainly useful for adding additional info when defining ad-hoc tasks inside
+// a Harness.Exec block.
+func LogStep(text string) {
+	fmt.Println(
+		color.MagentaString(" ⌘"),
+		color.New(color.Bold).Sprint(text),
+	)
+}
+
 // Task defines the basic function that the harness executes.
 // Additional configuration and tweaks can be done by using clojures which return
 // Tasks.

--- a/runner.go
+++ b/runner.go
@@ -64,7 +64,7 @@ func (r *TaskRunner) Exec() error {
 	}()
 
 	if !r.quiet {
-		logstep(fmt.Sprint(r.Executable, " ", strings.Join(r.Arguments, " ")))
+		LogStep(fmt.Sprint(r.Executable, " ", strings.Join(r.Arguments, " ")))
 	}
 
 	err = r.cmd.Run()
@@ -91,14 +91,6 @@ func Run(ctx context.Context, program string, opts ...RunnerOpt) error {
 	}
 
 	return rnr.Exec()
-}
-
-// fancy-ish log of a task step.
-func logstep(text string) {
-	fmt.Println(
-		color.MagentaString(" ⌘"),
-		color.New(color.Bold).Sprint(text),
-	)
 }
 
 // RunnerOpt allows customizing the behavior of the command runner.


### PR DESCRIPTION
when a project has a bunch of binaries to be downloaded, the boilerplate around this is very repetitive and noisy

this pr introduces a new commons task that receives a list of binaries, and calls `Ensure` on all of them, collecting and reporting errors at the end

sadly, to achieve this I have to introduce a breaking change, because the contructor method returning an error made things harder to manage; since I found myself always ignoring the constructor error either way I've decided to move the empty version check to `Ensure` and have the constructor always succeed

this project is still v0 so I prefer to fix it now instead of introducing other hacks/methods to work around this

usage example
```go
// setup local development environment
func Setup(ctx context.Context) error {
	return h.Execute(
		ctx,
		commons.Provision(
			binary.New(
				"temporal", "latest", binary.GoBinary("github.com/temporalio/cli/cmd/temporal"),
			),
			binary.New(
				"grafana", "12.0.0",
				binary.RemoteArchiveDownload(
					"https://dl.grafana.com/oss/release/grafana-{{.Version}}.{{.GOOS}}-{{.GOARCH}}.tar.gz",
					map[string]string{
						"grafana-v{{.Version}}/bin/grafana": "grafana",
					},
				),
			),
			binary.New(
				"alloy", "1.8.3",
				binary.RemoteArchiveDownload(
					"https://github.com/grafana/alloy/releases/download/v{{.Version}}/alloy-{{.GOOS}}-{{.GOARCH}}.zip",
					map[string]string{
						"alloy-{{.GOOS}}-{{.GOARCH}}": "alloy",
					},
				),
			),
		),
	)
}
```

output
<img width="1040" alt="Screenshot 2025-05-16 at 15 30 23" src="https://github.com/user-attachments/assets/21e3e711-08c1-4c0a-ad7b-9f8a205ea987" />
