### PR TITLE
feat(binary): add ArchiveExtension template parameter

### DIFF
--- a/binary/binary.go
+++ b/binary/binary.go
@@ -54,11 +54,12 @@ func New(command, version string, origin Origin, options ...Option) *Binary {
 		GOOS:   runtime.GOOS,
 		GOARCH: runtime.GOARCH,
 
-		Directory: bin.directory,
-		Name:      command,
-		Cmd:       cmdQualifiedPath,
-		Version:   bin.version,
-		Extension: extension,
+		Directory:        bin.directory,
+		Name:             command,
+		Cmd:              cmdQualifiedPath,
+		Version:          bin.version,
+		Extension:        extension,
+		ArchiveExtension: ".tar.gz",
 	}
 
 	for _, opt := range options {

--- a/binary/options.go
+++ b/binary/options.go
@@ -36,6 +36,20 @@ func WithGOARCHMapping(mapping map[string]string) Option {
 	}
 }
 
+// WithGOOSArchiveExtensionMapping allows remapping the value of ArchiveExtension in the template
+// before triggering the installation.
+// This is useful for example in cases where different compression methods are used
+// across different platforms.
+// The key of the map is the GOOS value and the value is the wanted
+// replacement, e.g. {"windows": ".zip"}.
+func WithGOOSArchiveExtensionMapping(mapping map[string]string) Option {
+	return func(b *Binary) {
+		if replacement, ok := mapping[b.template.GOOS]; ok {
+			b.template.ArchiveExtension = replacement
+		}
+	}
+}
+
 // WithVersionCmd allows customizing the command that is run to check the
 // version of the binary. The format string should contain a single `%s`
 // placeholder that will be replaced with the binary's command name.

--- a/binary/origin.go
+++ b/binary/origin.go
@@ -87,7 +87,7 @@ type remotearchive struct {
 // RemoteArchiveDownload creates a new Origin that downloads and extracts binaries from
 // a compressed archive. The URL can contain template variables that will be resolved
 // using the [Template] values during installation.
-// e.g. "https://github.com/aevea/commitsar/releases/download/v{{.Version}}/commitsar_{{.Version}}_{{.GOOS}}_{{.GOARCH}}.tar.gz",
+// e.g. "https://github.com/aevea/commitsar/releases/download/v{{.Version}}/commitsar_{{.Version}}_{{.GOOS}}_{{.GOARCH}}{{.ArchiveExtension}}",
 //
 // The binaries parameter maps archive paths to the desired binary names in the
 // installation directory. Only files specified in this map will be extracted.

--- a/binary/template.go
+++ b/binary/template.go
@@ -24,6 +24,8 @@ type Template struct {
 	// Extension is the file extension for the binary.
 	// Usually it's empty on unix systems and ".exe" on windows.
 	Extension string
+	// ArchiveExtension is the archive extension for the archive containing the binary.
+	ArchiveExtension string
 }
 
 // Resolve executes the provided format string as a template with the Template's fields.


### PR DESCRIPTION
Some packages are archived using different compression algorithms per OS. Most typically use `.tar.gz`, so that's what we default to, but we need to allow for overrides on different systems.

Add `WithGOOSArchiveExtensionMapping` option which allows to specify a mapping of GOOS to archive extensions.