### PR TITLE
feat: add zed task generator

### DIFF
--- a/gen/cmd/main.go
+++ b/gen/cmd/main.go
@@ -1,0 +1,102 @@
+// Command gen is a standalone CLI for the harness code generators.
+// It can be used via //go:generate without requiring mage or the harness
+// runtime to be present in the consuming project.
+//
+// Usage:
+//
+//	go run github.com/aexvir/harness/gen/cmd <generator> <action> [flags]
+//
+// Example:
+//
+//	//go:generate go run github.com/aexvir/harness/gen/cmd zed task --label="test" --command="go test ./..."
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/aexvir/harness/gen"
+	"github.com/urfave/cli/v3"
+)
+
+func main() {
+	if err := buildApp().Run(context.Background(), os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "gen:", err)
+		os.Exit(1)
+	}
+}
+
+func buildApp() *cli.Command {
+	return &cli.Command{
+		Name:  "gen",
+		Usage: "harness code generators",
+		// called when no subcommand matches or no args given
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			if cmd.NArg() > 0 {
+				return fmt.Errorf("unknown generator %q; supported: zed", cmd.Args().First())
+			}
+			return fmt.Errorf("expected a generator command")
+		},
+		Commands: []*cli.Command{
+			{
+				Name:  "zed",
+				Usage: "Zed editor generators",
+				// called when no subcommand of zed matches
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					if cmd.NArg() > 0 {
+						return fmt.Errorf("unknown zed action %q; supported: task", cmd.Args().First())
+					}
+					return fmt.Errorf("expected an action for zed")
+				},
+				Commands: []*cli.Command{
+					{
+						Name:  "task",
+						Usage: "upsert a task into .zed/tasks.json",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:     "label",
+								Usage:    "task `label`",
+								Required: true,
+							},
+							&cli.StringFlag{
+								Name:     "command",
+								Usage:    "`command` to run",
+								Required: true,
+							},
+							&cli.StringSliceFlag{
+								Name:  "args",
+								Usage: "`argument` passed to command (may be repeated)",
+							},
+							&cli.StringFlag{
+								Name:  "file",
+								Usage: "path to tasks.json `file`",
+								Value: ".zed/tasks.json",
+							},
+							&cli.StringFlag{
+								Name:  "reveal",
+								Usage: "when to reveal the task panel: always, never, focus",
+							},
+						},
+						Action: func(ctx context.Context, cmd *cli.Command) error {
+							args := cmd.StringSlice("args")
+							if len(args) == 0 {
+								args = nil
+							}
+							task := gen.ZedTask{
+								Label:   cmd.String("label"),
+								Command: cmd.String("command"),
+								Args:    args,
+								Reveal:  cmd.String("reveal"),
+							}
+							return gen.New().UpsertZedTasks(
+								gen.WithExtraTasks(task),
+								gen.WithZedTasksFile(cmd.String("file")),
+							)(ctx)
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/gen/cmd/main_test.go
+++ b/gen/cmd/main_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aexvir/harness/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testRun invokes the CLI app with the given args (the binary name is prepended
+// automatically). Help output is suppressed so tests stay clean.
+func testRun(t *testing.T, args ...string) error {
+	t.Helper()
+	cmd := buildApp()
+	cmd.Writer = io.Discard
+	cmd.ErrWriter = io.Discard
+	return cmd.Run(context.Background(), append([]string{"gen"}, args...))
+}
+
+func TestRun(t *testing.T) {
+	t.Run("no arguments returns error",
+		func(t *testing.T) {
+			err := testRun(t)
+			require.Error(t, err)
+		},
+	)
+
+	t.Run("unknown generator returns error",
+		func(t *testing.T) {
+			err := testRun(t, "unknown", "task")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unknown generator")
+		},
+	)
+
+	t.Run("zed with no action returns error",
+		func(t *testing.T) {
+			err := testRun(t, "zed")
+			require.Error(t, err)
+		},
+	)
+
+	t.Run("unknown zed action returns error",
+		func(t *testing.T) {
+			err := testRun(t, "zed", "unknown")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unknown zed action")
+		},
+	)
+}
+
+func TestZedTask(t *testing.T) {
+	t.Run("missing --label returns error",
+		func(t *testing.T) {
+			err := testRun(t, "zed", "task", "--command=go test ./...")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "label")
+		},
+	)
+
+	t.Run("missing --command returns error",
+		func(t *testing.T) {
+			err := testRun(t, "zed", "task", "--label=test")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "command")
+		},
+	)
+
+	t.Run("unknown flag returns error",
+		func(t *testing.T) {
+			err := testRun(t, "zed", "task", "--label=test", "--command=go test", "--bogus=x")
+			require.Error(t, err)
+		},
+	)
+
+	t.Run("creates tasks.json with the given task",
+		func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".zed", "tasks.json")
+
+			err := testRun(t, "zed", "task",
+				"--label=test",
+				"--command=go test ./...",
+				"--file="+path,
+			)
+			require.NoError(t, err)
+
+			tasks := readTasks(t, path)
+			require.Len(t, tasks, 1)
+			assert.Equal(t, "test", tasks[0].Label)
+			assert.Equal(t, "go test ./...", tasks[0].Command)
+			assert.Empty(t, tasks[0].Args)
+		},
+	)
+
+	t.Run("repeatable --args are collected in order",
+		func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "tasks.json")
+
+			err := testRun(t, "zed", "task",
+				"--label=docker up",
+				"--command=docker",
+				"--args=compose",
+				"--args=up",
+				"--args=-d",
+				"--file="+path,
+			)
+			require.NoError(t, err)
+
+			tasks := readTasks(t, path)
+			require.Len(t, tasks, 1)
+			assert.Equal(t, "docker", tasks[0].Command)
+			assert.Equal(t, []string{"compose", "up", "-d"}, tasks[0].Args)
+		},
+	)
+
+	t.Run("--reveal flag is written to the task",
+		func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "tasks.json")
+
+			err := testRun(t, "zed", "task",
+				"--label=test",
+				"--command=go test ./...",
+				"--reveal=always",
+				"--file="+path,
+			)
+			require.NoError(t, err)
+
+			tasks := readTasks(t, path)
+			require.Len(t, tasks, 1)
+			assert.Equal(t, "always", tasks[0].Reveal)
+		},
+	)
+
+	t.Run("re-run updates command; user-added fields are preserved",
+		func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "tasks.json")
+
+			// first run: create the task
+			require.NoError(t, testRun(t, "zed", "task",
+				"--label=test",
+				"--command=go test ./...",
+				"--file="+path,
+			))
+
+			// simulate user editing the file (add reveal)
+			tasks := readTasks(t, path)
+			tasks[0].Reveal = "focus"
+			writeTasksToFile(t, path, tasks)
+
+			// second run: update the command
+			require.NoError(t, testRun(t, "zed", "task",
+				"--label=test",
+				"--command=gotestsum ./...",
+				"--file="+path,
+			))
+
+			tasks = readTasks(t, path)
+			require.Len(t, tasks, 1)
+			assert.Equal(t, "gotestsum ./...", tasks[0].Command, "command must be refreshed")
+			assert.Equal(t, "focus", tasks[0].Reveal, "user-set reveal must be preserved")
+		},
+	)
+
+	t.Run("default file path is .zed/tasks.json in cwd",
+		func(t *testing.T) {
+			original, err := os.Getwd()
+			require.NoError(t, err)
+			dir := t.TempDir()
+			require.NoError(t, os.Chdir(dir))
+			t.Cleanup(func() { require.NoError(t, os.Chdir(original)) })
+
+			err = testRun(t, "zed", "task", "--label=build", "--command=go build ./...")
+			require.NoError(t, err)
+			assert.FileExists(t, filepath.Join(dir, ".zed", "tasks.json"))
+		},
+	)
+}
+
+func readTasks(t *testing.T, path string) []gen.ZedTask {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var tasks []gen.ZedTask
+	require.NoError(t, json.Unmarshal(data, &tasks))
+	return tasks
+}
+
+func writeTasksToFile(t *testing.T, path string, tasks []gen.ZedTask) {
+	t.Helper()
+	data, err := json.MarshalIndent(tasks, "", "  ")
+	require.NoError(t, err)
+	data = append(data, '\n')
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+}

--- a/gen/doc.go
+++ b/gen/doc.go
@@ -1,0 +1,17 @@
+// Package gen provides code generators that automate the creation and maintenance
+// of editor and tooling configuration files based on the mage targets defined in
+// a project.
+//
+// Generators read the available mage targets via [introspectMageTasks] and use
+// that information to produce or update configuration files so that all targets
+// are always reachable from within the editor or tooling without manual upkeep.
+//
+// Generators are designed to be idempotent and non-destructive: they only
+// manage the entries they own, leaving any user-added configuration untouched.
+// Per-entry ownership is determined by a naming convention rather than file-level
+// markers, so users can freely edit any other property of a generated entry and
+// those changes will survive subsequent generator runs.
+//
+// Create a [Generator] with [New] and call its methods:
+//   - [Generator.GenerateZedTasks] / [Generator.CleanupZedTasks] – Zed editor task integration
+package gen

--- a/gen/introspect.go
+++ b/gen/introspect.go
@@ -1,0 +1,125 @@
+package gen
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const defaultMageCmd = "mage"
+
+// Generator holds shared settings for all code generators that rely on mage
+// target introspection. Create one with [New] and call its methods to produce
+// editor or tooling configuration files.
+type Generator struct {
+	magecmd string
+	workdir string
+}
+
+// Option configures a [Generator].
+type Option func(*Generator)
+
+// WithMageCommand overrides the mage binary used to discover targets.
+// Defaults to "mage" (resolved from PATH).
+func WithMageCommand(cmd string) Option {
+	return func(g *Generator) { g.magecmd = cmd }
+}
+
+// WithWorkDir sets the working directory used when running mage -l.
+// Defaults to the current working directory.
+func WithWorkDir(dir string) Option {
+	return func(g *Generator) { g.workdir = dir }
+}
+
+// New returns a [Generator] with sensible defaults, modified by opts.
+func New(opts ...Option) *Generator {
+	gen := &Generator{magecmd: defaultMageCmd}
+	for _, opt := range opts {
+		opt(gen)
+	}
+	return gen
+}
+
+// target represents a single build target.
+type target struct {
+	name        string
+	description string
+}
+
+// introspectMageTasks runs mage -l using the given binary and working directory,
+// and returns the list of available targets.
+func (g *Generator) introspectMageTasks(ctx context.Context) ([]target, error) {
+	cmd := exec.CommandContext(ctx, g.magecmd, "-l")
+	if g.workdir != "" {
+		cmd.Dir = g.workdir
+	}
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = nil
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%s -l: %w", g.magecmd, err)
+	}
+
+	return parseMageListOutput(stdout.String())
+}
+
+// parseMageListOutput parses the output of mage -l and returns the list of targets.
+//
+// The expected format is:
+//
+//	Targets:
+//	  format    format codebase using gofmt and goimports
+//	  lint*     lint the code (default)
+//	  test      run unit tests
+func parseMageListOutput(output string) ([]target, error) {
+	var targets []target
+
+	inTargets := false
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "Targets:") {
+			inTargets = true
+			continue
+		}
+
+		if !inTargets {
+			continue
+		}
+
+		// target lines are indented with at least one space
+		if len(line) == 0 || line[0] != ' ' {
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		fields := strings.Fields(trimmed)
+		if len(fields) == 0 {
+			continue
+		}
+
+		// strip the * suffix mage adds to the default target
+		name := strings.TrimSuffix(fields[0], "*")
+
+		// mage always lower-cases target names in -l output, but normalise
+		// defensively so callers can rely on a consistent casing
+		name = strings.ToLower(name)
+
+		// everything after the target name (and surrounding whitespace) is the description
+		var desc string
+		if len(fields) > 1 {
+			rest := strings.TrimPrefix(trimmed, fields[0])
+			desc = strings.TrimSpace(rest)
+		}
+
+		targets = append(targets, target{name: name, description: desc})
+	}
+
+	return targets, nil
+}

--- a/gen/introspect_test.go
+++ b/gen/introspect_test.go
@@ -1,0 +1,168 @@
+package gen
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMageListOutput(t *testing.T) {
+	t.Run("standard output with multiple targets",
+		func(t *testing.T) {
+			output := `Targets:
+  format    format codebase using gofmt and goimports
+  lint      lint the code using go mod tidy, commitsar and golangci-lint
+  test      run unit tests
+  tidy      run go mod tidy
+`
+			targets, err := parseMageListOutput(output)
+			require.NoError(t, err)
+
+			require.Len(t, targets, 4)
+			assert.Equal(t, "format", targets[0].name)
+			assert.Equal(t, "format codebase using gofmt and goimports", targets[0].description)
+			assert.Equal(t, "lint", targets[1].name)
+			assert.Equal(t, "lint the code using go mod tidy, commitsar and golangci-lint", targets[1].description)
+			assert.Equal(t, "test", targets[2].name)
+			assert.Equal(t, "run unit tests", targets[2].description)
+			assert.Equal(t, "tidy", targets[3].name)
+			assert.Equal(t, "run go mod tidy", targets[3].description)
+		},
+	)
+
+	t.Run("default target marked with asterisk is stripped",
+		func(t *testing.T) {
+			output := `Targets:
+  build*    build the project (default)
+  lint      lint the code
+`
+			targets, err := parseMageListOutput(output)
+			require.NoError(t, err)
+
+			require.Len(t, targets, 2)
+			assert.Equal(t, "build", targets[0].name, "asterisk suffix should be stripped")
+			assert.Equal(t, "build the project (default)", targets[0].description)
+			assert.Equal(t, "lint", targets[1].name)
+			assert.Equal(t, "lint the code", targets[1].description)
+		},
+	)
+
+	t.Run("single target with no description",
+		func(t *testing.T) {
+			output := `Targets:
+  nodesc
+`
+			targets, err := parseMageListOutput(output)
+			require.NoError(t, err)
+
+			require.Len(t, targets, 1)
+			assert.Equal(t, "nodesc", targets[0].name)
+			assert.Equal(t, "", targets[0].description)
+		},
+	)
+
+	t.Run("multiple targets middle one with no description",
+		func(t *testing.T) {
+			output := `Targets:
+  format      codebase using gofmt and goimports
+  generate
+  lint        the code using go mod tidy, commitsar and golangci-lint
+`
+			targets, err := parseMageListOutput(output)
+			require.NoError(t, err)
+
+			require.Len(t, targets, 3)
+			assert.Equal(t, "format", targets[0].name)
+			assert.Equal(t, "codebase using gofmt and goimports", targets[0].description)
+			assert.Equal(t, "generate", targets[1].name)
+			assert.Equal(t, "", targets[1].description)
+			assert.Equal(t, "lint", targets[2].name)
+			assert.Equal(t, "the code using go mod tidy, commitsar and golangci-lint", targets[2].description)
+		},
+	)
+
+	t.Run("target names are lowercased",
+		func(t *testing.T) {
+			output := `Targets:
+  BuildAll    build everything
+`
+			targets, err := parseMageListOutput(output)
+			require.NoError(t, err)
+
+			require.Len(t, targets, 1)
+			assert.Equal(t, "buildall", targets[0].name)
+		},
+	)
+
+	t.Run("empty output returns no targets",
+		func(t *testing.T) {
+			targets, err := parseMageListOutput("")
+			require.NoError(t, err)
+			assert.Empty(t, targets)
+		},
+	)
+
+	t.Run("output with no Targets section returns no targets",
+		func(t *testing.T) {
+			output := `mage: no magefiles found in current directory
+`
+			targets, err := parseMageListOutput(output)
+			require.NoError(t, err)
+			assert.Empty(t, targets)
+		},
+	)
+
+	t.Run("blank lines inside targets section are ignored",
+		func(t *testing.T) {
+			output := `Targets:
+  format    format code
+
+  lint      lint code
+`
+			targets, err := parseMageListOutput(output)
+			require.NoError(t, err)
+
+			require.Len(t, targets, 2)
+			assert.Equal(t, "format", targets[0].name)
+			assert.Equal(t, "lint", targets[1].name)
+		},
+	)
+}
+
+func TestIntrospectMageTasks(t *testing.T) {
+	skipOnWindows(t)
+
+	t.Run("returns targets from fakemage",
+		func(t *testing.T) {
+			gen := &Generator{magecmd: "testdata/fakemage.sh"}
+			targets, err := gen.introspectMageTasks(t.Context())
+			require.NoError(t, err)
+
+			require.Len(t, targets, 4)
+			assert.Equal(t, "build", targets[0].name)
+			assert.Equal(t, "build the project (default)", targets[0].description)
+			assert.Equal(t, "format", targets[1].name)
+			assert.Equal(t, "lint", targets[2].name)
+			assert.Equal(t, "test", targets[3].name)
+		},
+	)
+
+	t.Run("returns error when mage command fails",
+		func(t *testing.T) {
+			gen := &Generator{magecmd: "/nonexistent/mage"}
+			_, err := gen.introspectMageTasks(t.Context())
+			require.Error(t, err)
+		},
+	)
+}
+
+// skipOnWindows skips a test that requires shell scripts (.sh files).
+func skipOnWindows(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("test requires shell scripts (not supported on Windows)")
+	}
+}

--- a/gen/json.go
+++ b/gen/json.go
@@ -1,0 +1,167 @@
+package gen
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/tailscale/hujson"
+)
+
+// jsonDefinition is a stateful wrapper around a parsed hujson value whose
+// top level is either an array or an object. Use one of the constructors below
+// to load from disk.
+type jsonDefinition struct {
+	ast hujson.Value
+}
+
+// loadJsonFile reads path as a hujson value (JSONC: comments and trailing
+// commas are preserved). It accepts both top-level arrays and top-level
+// objects. It returns an error when the file does not exist; use
+// [loadJsonArrayFile] or [loadJsonObjectFile] for callers that want a default.
+func loadJsonFile(path string) (*jsonDefinition, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := hujson.Parse(data)
+	if err != nil {
+		return nil, fmt.Errorf("json parse %q: %w", path, err)
+	}
+	switch v.Value.(type) {
+	case *hujson.Array, *hujson.Object:
+		// ok
+	default:
+		return nil, fmt.Errorf("json parse %q: expected a json array or object at top level", path)
+	}
+	return &jsonDefinition{ast: v}, nil
+}
+
+// loadJsonArrayFile is like [loadJsonFile] but returns an empty-array
+// definition when the file does not exist, so callers can unconditionally
+// append to it.
+func loadJsonArrayFile(path string) (*jsonDefinition, error) {
+	def, err := loadJsonFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		v, _ := hujson.Parse([]byte("[]\n"))
+		return &jsonDefinition{ast: v}, nil
+	}
+	return def, err
+}
+
+// loadJsonObjectFile is like [loadJsonFile] but returns an empty-object
+// definition when the file does not exist, so callers can unconditionally
+// set fields on it.
+func loadJsonObjectFile(path string) (*jsonDefinition, error) {
+	def, err := loadJsonFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		v, _ := hujson.Parse([]byte("{}\n"))
+		return &jsonDefinition{ast: v}, nil
+	}
+	return def, err
+}
+
+// Array returns the top-level hujson.Array, or nil if the root is not an array.
+func (d *jsonDefinition) Array() *hujson.Array {
+	arr, _ := d.ast.Value.(*hujson.Array)
+	return arr
+}
+
+// Object returns the top-level hujson.Object, or nil if the root is not an object.
+func (d *jsonDefinition) Object() *hujson.Object {
+	obj, _ := d.ast.Value.(*hujson.Object)
+	return obj
+}
+
+// WriteToFile writes the definition to disk byte-for-byte (no reformatting).
+// Parent directories are created as needed.
+func (d *jsonDefinition) WriteToFile(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	d.ast.Format()
+	data := d.ast.Pack()
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		data = append(data, '\n')
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// memberKey returns the unquoted string key of an ObjectMember.
+func (d *jsonDefinition) memberKey(m hujson.ObjectMember) string {
+	if lit, ok := m.Name.Value.(hujson.Literal); ok {
+		return lit.String()
+	}
+	return ""
+}
+
+// findMember returns the index of the member with the given key, or -1.
+func (d *jsonDefinition) findMember(obj *hujson.Object, key string) int {
+	for i := range obj.Members {
+		if d.memberKey(obj.Members[i]) == key {
+			return i
+		}
+	}
+	return -1
+}
+
+// setMember sets the value of an existing member with the given key, or
+// creates a new member if the key doesn't exist. The value is marshalled
+// through JSON into the hujson AST, preserving any comments or whitespace
+// on the existing member.
+func (d *jsonDefinition) setMember(obj *hujson.Object, key string, v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	val, err := hujson.Parse(b)
+	if err != nil {
+		return err
+	}
+	if i := d.findMember(obj, key); i >= 0 {
+		obj.Members[i].Value.Value = val.Value
+		return nil
+	}
+	obj.Members = append(obj.Members, hujson.ObjectMember{
+		Name:  hujson.Value{Value: hujson.String(key)},
+		Value: val,
+	})
+	return nil
+}
+
+// deleteMember removes the member with the given key. No-op if absent.
+func (d *jsonDefinition) deleteMember(obj *hujson.Object, key string) {
+	out := obj.Members[:0]
+	for _, m := range obj.Members {
+		if d.memberKey(m) != key {
+			out = append(out, m)
+		}
+	}
+	obj.Members = out
+}
+
+// appendElement marshals v as JSON, parses it as hujson, and appends it
+// to the array. Each new element is preceded by a newline. If the value
+// is an object, a newline is injected before the first member so that
+// Format() expands it into multi-line form.
+func (d *jsonDefinition) appendElement(arr *hujson.Array, v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	val, err := hujson.Parse(b)
+	if err != nil {
+		return err
+	}
+	if obj, ok := val.Value.(*hujson.Object); ok && len(obj.Members) > 0 {
+		obj.Members[0].Name.BeforeExtra = hujson.Extra("\n")
+	}
+	val.BeforeExtra = hujson.Extra("\n")
+	arr.Elements = append(arr.Elements, val)
+	return nil
+}

--- a/gen/json_test.go
+++ b/gen/json_test.go
@@ -1,0 +1,286 @@
+package gen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tailscale/hujson"
+)
+
+const (
+	testdataJSONCArray = "testdata/jsonc_array.json"
+	testdataJSONObject = "testdata/json_object.json"
+	testdataTasks      = "testdata/tasks.json"
+)
+
+// defFrom wraps a raw hujson.Value in a jsonDefinition so the helper methods
+// are callable in unit tests that don't go through loadJsonFile.
+func defFrom(v hujson.Value) *jsonDefinition {
+	return &jsonDefinition{ast: v}
+}
+
+func TestLoadJsonFile(t *testing.T) {
+	t.Run("missing file returns error", func(t *testing.T) {
+		_, err := loadJsonFile(filepath.Join(t.TempDir(), "nonexistent.json"))
+		require.Error(t, err)
+	})
+
+	t.Run("JSONC array with comments and trailing commas is parsed", func(t *testing.T) {
+		def, err := loadJsonFile(testdataJSONCArray)
+		require.NoError(t, err)
+		arr := def.Array()
+		require.NotNil(t, arr)
+		assert.Len(t, arr.Elements, 1)
+	})
+
+	t.Run("JSONC object with comments and trailing commas is parsed", func(t *testing.T) {
+		def, err := loadJsonFile(testdataJSONObject)
+		require.NoError(t, err)
+		assert.NotNil(t, def.Object())
+	})
+}
+
+func TestLoadJsonArrayFile(t *testing.T) {
+	t.Run("missing file returns empty array definition", func(t *testing.T) {
+		def, err := loadJsonArrayFile(filepath.Join(t.TempDir(), "nonexistent.json"))
+		require.NoError(t, err)
+		arr := def.Array()
+		require.NotNil(t, arr)
+		assert.Empty(t, arr.Elements)
+	})
+
+	t.Run("existing array file is loaded normally", func(t *testing.T) {
+		def, err := loadJsonArrayFile(testdataJSONCArray)
+		require.NoError(t, err)
+		arr := def.Array()
+		require.NotNil(t, arr)
+		assert.Len(t, arr.Elements, 1)
+	})
+}
+
+func TestLoadJsonObjectFile(t *testing.T) {
+	t.Run("missing file returns empty object definition", func(t *testing.T) {
+		def, err := loadJsonObjectFile(filepath.Join(t.TempDir(), "nonexistent.json"))
+		require.NoError(t, err)
+		obj := def.Object()
+		require.NotNil(t, obj)
+		assert.Empty(t, obj.Members)
+	})
+
+	t.Run("existing object file is loaded normally", func(t *testing.T) {
+		def, err := loadJsonObjectFile(testdataJSONObject)
+		require.NoError(t, err)
+		assert.NotNil(t, def.Object())
+	})
+}
+
+func TestFindMember(t *testing.T) {
+	v, _ := hujson.Parse([]byte(`{"a":1,"b":2,"c":3}`))
+	def := defFrom(v)
+	obj := v.Value.(*hujson.Object)
+
+	t.Run("finds existing key", func(t *testing.T) {
+		assert.Equal(t, 0, def.findMember(obj, "a"))
+		assert.Equal(t, 1, def.findMember(obj, "b"))
+		assert.Equal(t, 2, def.findMember(obj, "c"))
+	})
+
+	t.Run("returns -1 for missing key", func(t *testing.T) {
+		assert.Equal(t, -1, def.findMember(obj, "missing"))
+	})
+}
+
+func TestSetMember(t *testing.T) {
+	t.Run("updates existing key", func(t *testing.T) {
+		v, _ := hujson.Parse([]byte(`{"x":"old"}`))
+		def := defFrom(v)
+		obj := v.Value.(*hujson.Object)
+		require.NoError(t, def.setMember(obj, "x", "new"))
+		assert.Equal(t, `{"x":"new"}`, string(v.Pack()))
+	})
+
+	t.Run("creates missing key", func(t *testing.T) {
+		v, _ := hujson.Parse([]byte(`{}`))
+		def := defFrom(v)
+		obj := v.Value.(*hujson.Object)
+		require.NoError(t, def.setMember(obj, "foo", "bar"))
+		assert.Equal(t, `{"foo":"bar"}`, string(v.Pack()))
+	})
+
+	t.Run("preserves other members", func(t *testing.T) {
+		v, _ := hujson.Parse([]byte(`{"a":1,"b":2}`))
+		def := defFrom(v)
+		obj := v.Value.(*hujson.Object)
+		require.NoError(t, def.setMember(obj, "a", 99))
+		packed := string(v.Pack())
+		assert.Contains(t, packed, `99`)
+		assert.Contains(t, packed, `"b":2`)
+	})
+
+	t.Run("replaces with complex value", func(t *testing.T) {
+		v, _ := hujson.Parse([]byte(`{"x":null}`))
+		def := defFrom(v)
+		obj := v.Value.(*hujson.Object)
+		require.NoError(t, def.setMember(obj, "x", []string{"a", "b"}))
+		assert.Equal(t, `{"x":["a","b"]}`, string(v.Pack()))
+	})
+}
+
+func TestDeleteMember(t *testing.T) {
+	t.Run("removes existing key", func(t *testing.T) {
+		v, _ := hujson.Parse([]byte(`{"a":"1","b":"2"}`))
+		def := defFrom(v)
+		obj := v.Value.(*hujson.Object)
+		def.deleteMember(obj, "a")
+		assert.Equal(t, `{"b":"2"}`, string(v.Pack()))
+	})
+
+	t.Run("no-op when key absent", func(t *testing.T) {
+		v, _ := hujson.Parse([]byte(`{"a":"1"}`))
+		def := defFrom(v)
+		obj := v.Value.(*hujson.Object)
+		def.deleteMember(obj, "missing")
+		assert.Equal(t, `{"a":"1"}`, string(v.Pack()))
+	})
+}
+
+func TestAppendElement(t *testing.T) {
+	t.Run("appends to array", func(t *testing.T) {
+		v, _ := hujson.Parse([]byte(`[{"x":1}]`))
+		def := defFrom(v)
+		arr := v.Value.(*hujson.Array)
+		require.NoError(t, def.appendElement(arr, map[string]int{"x": 2}))
+		assert.Len(t, arr.Elements, 2)
+	})
+
+	t.Run("appends string value", func(t *testing.T) {
+		v, _ := hujson.Parse([]byte(`["a"]`))
+		def := defFrom(v)
+		arr := v.Value.(*hujson.Array)
+		require.NoError(t, def.appendElement(arr, "b"))
+		assert.Len(t, arr.Elements, 2)
+		assert.Contains(t, string(v.Pack()), `"b"`)
+	})
+}
+
+func TestWriteToFile(t *testing.T) {
+	t.Run("creates parent dirs and ends with newline", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "a", "b", "f.json")
+		def := &jsonDefinition{}
+		def.ast, _ = hujson.Parse([]byte(`[]`))
+		require.NoError(t, def.WriteToFile(path))
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, byte('\n'), data[len(data)-1])
+	})
+
+	t.Run("array preserves comments and formatting is idempotent", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "f.json")
+		src, err := os.ReadFile(testdataJSONCArray)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, src, 0o644))
+
+		def, err := loadJsonFile(path)
+		require.NoError(t, err)
+		require.NoError(t, def.WriteToFile(path))
+
+		first, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Contains(t, string(first), "// comment", "comments must survive")
+
+		// Write again: output must be stable.
+		def2, err := loadJsonFile(path)
+		require.NoError(t, err)
+		require.NoError(t, def2.WriteToFile(path))
+		second, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, first, second, "formatting must be idempotent")
+	})
+
+	t.Run("object preserves comments and formatting is idempotent", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "f.json")
+		src, err := os.ReadFile(testdataJSONObject)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, src, 0o644))
+
+		def, err := loadJsonFile(path)
+		require.NoError(t, err)
+		require.NoError(t, def.WriteToFile(path))
+
+		first, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Contains(t, string(first), "// JSONC comment", "comments must survive")
+
+		// Write again: output must be stable.
+		def2, err := loadJsonFile(path)
+		require.NoError(t, err)
+		require.NoError(t, def2.WriteToFile(path))
+		second, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, first, second, "formatting must be idempotent")
+	})
+}
+
+func TestMemberKey(t *testing.T) {
+	v, _ := hujson.Parse([]byte(`{"hello":"world"}`))
+	def := defFrom(v)
+	obj := v.Value.(*hujson.Object)
+	assert.Equal(t, "hello", def.memberKey(obj.Members[0]))
+}
+
+func TestTasksJsonRoundtrip(t *testing.T) {
+	src, err := os.ReadFile(testdataTasks)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "tasks.json")
+	require.NoError(t, os.WriteFile(path, src, 0o644))
+
+	def, err := loadJsonFile(path)
+	require.NoError(t, err)
+
+	arr := def.Array()
+	require.NotNil(t, arr)
+
+	// Find "mage: fmt" by label and patch its command.
+	idx := def.findByLabel(arr, "mage: fmt")
+	require.GreaterOrEqual(t, idx, 0)
+	fmtObj := arr.Elements[idx].Value.(*hujson.Object)
+	require.NoError(t, def.setMember(fmtObj, "command", "mage2"))
+
+	// Delete args from "mage: test".
+	idx = def.findByLabel(arr, "mage: test")
+	require.GreaterOrEqual(t, idx, 0)
+	testObj := arr.Elements[idx].Value.(*hujson.Object)
+	def.deleteMember(testObj, "args")
+
+	// Append a new entry.
+	require.NoError(t, def.appendElement(arr, map[string]string{"label": "new", "command": "true"}))
+
+	// Remove the "custom" entry by filtering.
+	kept := arr.Elements[:0]
+	for _, elem := range arr.Elements {
+		if def.elemLabel(elem) != "custom" {
+			kept = append(kept, elem)
+		}
+	}
+	arr.Elements = kept
+
+	require.NoError(t, def.WriteToFile(path))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	packed := string(got)
+	assert.Contains(t, packed, `"mage2"`)
+	assert.NotContains(t, packed, `"custom"`)
+	assert.Contains(t, packed, `"new"`)
+	// mage: test still present but no longer has args
+	assert.Contains(t, packed, `"mage: test"`)
+	// mage: fmt still has its args
+	assert.Contains(t, packed, `"mage: fmt"`)
+	assert.Contains(t, packed, `"args"`)
+}

--- a/gen/testdata/fakemage.sh
+++ b/gen/testdata/fakemage.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# fakemage.sh simulates `mage -l` output for use in hermetic tests.
+# Only the `-l` flag is recognised; all other invocations exit with an error.
+case "$1" in
+  -l)
+    printf "Targets:\n"
+    printf "  build*    build the project (default)\n"
+    printf "  format    format codebase using gofmt and goimports\n"
+    printf "  lint      lint the code\n"
+    printf "  test      run unit tests\n"
+    exit 0
+    ;;
+  *)
+    printf "fakemage: unsupported arguments\n" >&2
+    exit 1
+    ;;
+esac

--- a/gen/testdata/json_object.json
+++ b/gen/testdata/json_object.json
@@ -1,0 +1,5 @@
+{
+  // JSONC comment
+  "key": "val",
+  "tags": ["a", "b",],
+}

--- a/gen/testdata/jsonc_array.json
+++ b/gen/testdata/jsonc_array.json
@@ -1,0 +1,4 @@
+[
+  // comment
+  {"key": "val",},
+]

--- a/gen/testdata/object_not_array.json
+++ b/gen/testdata/object_not_array.json
@@ -1,0 +1,1 @@
+{"not": "an array"}

--- a/gen/testdata/tasks.json
+++ b/gen/testdata/tasks.json
@@ -1,0 +1,5 @@
+[
+  {"label": "mage: fmt", "command": "mage", "args": ["fmt"]},
+  {"label": "mage: test", "command": "mage", "args": ["test"]},
+  {"label": "custom", "command": "echo"}
+]

--- a/gen/zedtasks.go
+++ b/gen/zedtasks.go
@@ -1,0 +1,221 @@
+package gen
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aexvir/harness"
+	"github.com/tailscale/hujson"
+)
+
+const (
+	defaultTasksFile = ".zed/tasks.json"
+
+	// mageTaskPrefix is the label prefix used for all generator-owned task entries.
+	mageTaskPrefix = "mage: "
+)
+
+// ZedTask represents a single entry in Zed's tasks.json file.
+//
+// https://zed.dev/docs/tasks
+type ZedTask struct {
+	Label               string            `json:"label"`
+	Command             string            `json:"command"`
+	Args                []string          `json:"args,omitempty"`
+	Env                 map[string]string `json:"env,omitempty"`
+	CWD                 string            `json:"cwd,omitempty"`
+	UseNewTerminal      *bool             `json:"use_new_terminal,omitempty"`
+	AllowConcurrentRuns *bool             `json:"allow_concurrent_runs,omitempty"`
+	Reveal              string            `json:"reveal,omitempty"`
+	Hide                string            `json:"hide,omitempty"`
+	ShowSummary         *bool             `json:"show_summary,omitempty"`
+	ShowCommand         *bool             `json:"show_command,omitempty"`
+	Tags                []string          `json:"tags,omitempty"`
+}
+
+type zedtasksconf struct {
+	taskfile string
+	extra    []ZedTask
+}
+
+// ZedTasksOpt configures the Zed tasks generator.
+type ZedTasksOpt func(c *zedtasksconf)
+
+// WithZedTasksFile overrides the path to the Zed tasks file.
+// Defaults to ".zed/tasks.json" relative to the working directory.
+func WithZedTasksFile(path string) ZedTasksOpt {
+	return func(c *zedtasksconf) { c.taskfile = path }
+}
+
+// WithExtraTasks registers additional tasks that are not derived from mage
+// targets but should still be kept in sync by the generator.
+func WithExtraTasks(tasks ...ZedTask) ZedTasksOpt {
+	return func(c *zedtasksconf) { c.extra = append(c.extra, tasks...) }
+}
+
+// GenerateZedTasks returns a harness task that ensures every mage target has a
+// corresponding entry in the Zed tasks file (.zed/tasks.json by default).
+//
+// Merge rules:
+//   - Existing entry → only command and args are refreshed; all other fields preserved.
+//   - Missing entry → appended.
+//   - Stale entry (target gone from mage -l) → left as-is; use [Generator.CleanupZedTasks] to remove.
+//
+// Manual tasks provided via [WithExtraTasks] follow the same rules.
+func (g *Generator) GenerateZedTasks(opts ...ZedTasksOpt) harness.Task {
+	return func(ctx context.Context) error {
+		conf := loadZedConf(opts)
+
+		targets, err := g.introspectMageTasks(ctx)
+		if err != nil {
+			return fmt.Errorf("introspect mage tasks: %w", err)
+		}
+
+		incoming := make([]ZedTask, 0, len(targets)+len(conf.extra))
+		for _, t := range targets {
+			incoming = append(incoming, ZedTask{Label: mageTaskLabel(t.name), Command: g.magecmd, Args: []string{t.name}})
+		}
+		incoming = append(incoming, conf.extra...)
+
+		return applyTasks(conf.taskfile, incoming)
+	}
+}
+
+// CleanupZedTasks returns a harness task that removes stale generator-owned
+// entries from the Zed tasks file. An entry is stale when its label matches
+// the "mage: <target>" pattern but the corresponding target no longer appears
+// in mage -l. Non-mage entries and entries for active targets are never touched.
+func (g *Generator) CleanupZedTasks(opts ...ZedTasksOpt) harness.Task {
+	return func(ctx context.Context) error {
+		conf := loadZedConf(opts)
+
+		targets, err := g.introspectMageTasks(ctx)
+		if err != nil {
+			return fmt.Errorf("introspect mage tasks: %w", err)
+		}
+
+		active := make(map[string]bool, len(targets))
+		for _, t := range targets {
+			active[mageTaskLabel(t.name)] = true
+		}
+
+		def, err := loadJsonArrayFile(conf.taskfile)
+		if err != nil {
+			return fmt.Errorf("read tasks file: %w", err)
+		}
+
+		arr := def.Array()
+		if arr == nil {
+			return fmt.Errorf("tasks file is not an array")
+		}
+
+		// Filter out stale mage tasks.
+		kept := arr.Elements[:0]
+		for _, elem := range arr.Elements {
+			label := def.elemLabel(elem)
+			if isMageTask(label) && !active[label] {
+				continue
+			}
+			kept = append(kept, elem)
+		}
+		arr.Elements = kept
+
+		return def.WriteToFile(conf.taskfile)
+	}
+}
+
+// UpsertZedTasks returns a task that upserts tasks provided via [WithExtraTasks]
+// into the Zed tasks file without running mage -l.
+//
+// This is intended for use via //go:generate or in any context where mage is
+// not available. The same merge semantics as [Generator.GenerateZedTasks] apply.
+func (g *Generator) UpsertZedTasks(opts ...ZedTasksOpt) harness.Task {
+	return func(_ context.Context) error {
+		conf := loadZedConf(opts)
+		return applyTasks(conf.taskfile, conf.extra)
+	}
+}
+
+// applyTasks loads the array from path, upserts tasks, and saves it back.
+// For each task: if an entry with the same label exists, only its command and
+// args members are updated; all other members are left untouched. Missing
+// entries are appended.
+func applyTasks(path string, tasks []ZedTask) error {
+	def, err := loadJsonArrayFile(path)
+	if err != nil {
+		return fmt.Errorf("read tasks file: %w", err)
+	}
+
+	arr := def.Array()
+	if arr == nil {
+		return fmt.Errorf("tasks file is not an array")
+	}
+
+	for _, task := range tasks {
+		idx := def.findByLabel(arr, task.Label)
+		if idx >= 0 {
+			obj, ok := arr.Elements[idx].Value.(*hujson.Object)
+			if !ok {
+				continue
+			}
+			if err := def.setMember(obj, "command", task.Command); err != nil {
+				return fmt.Errorf("set command for %q: %w", task.Label, err)
+			}
+			if len(task.Args) > 0 {
+				if err := def.setMember(obj, "args", task.Args); err != nil {
+					return fmt.Errorf("set args for %q: %w", task.Label, err)
+				}
+			} else {
+				def.deleteMember(obj, "args")
+			}
+		} else {
+			if err := def.appendElement(arr, task); err != nil {
+				return fmt.Errorf("append task %q: %w", task.Label, err)
+			}
+		}
+	}
+
+	return def.WriteToFile(path)
+}
+
+// findByLabel returns the 0-based array index of the first element whose
+// "label" member equals label, or -1 if not found.
+func (d *jsonDefinition) findByLabel(arr *hujson.Array, label string) int {
+	for i, elem := range arr.Elements {
+		if d.elemLabel(elem) == label {
+			return i
+		}
+	}
+	return -1
+}
+
+func mageTaskLabel(name string) string { return mageTaskPrefix + name }
+func isMageTask(label string) bool     { return strings.HasPrefix(label, mageTaskPrefix) }
+
+// elemLabel returns the string value of the "label" member of a JSON object
+// element. Returns "" if the element is not an object or has no "label" key.
+func (d *jsonDefinition) elemLabel(elem hujson.Value) string {
+	obj, ok := elem.Value.(*hujson.Object)
+	if !ok {
+		return ""
+	}
+	for _, m := range obj.Members {
+		if d.memberKey(m) == "label" {
+			if lit, ok := m.Value.Value.(hujson.Literal); ok {
+				return lit.String()
+			}
+		}
+	}
+	return ""
+}
+
+func loadZedConf(opts []ZedTasksOpt) *zedtasksconf {
+	conf := &zedtasksconf{
+		taskfile: defaultTasksFile,
+	}
+	for _, opt := range opts {
+		opt(conf)
+	}
+	return conf
+}

--- a/gen/zedtasks_test.go
+++ b/gen/zedtasks_test.go
@@ -1,0 +1,139 @@
+package gen
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tailscale/hujson"
+)
+
+// readTasks is a test helper that decodes the tasks file into a []ZedTask
+// slice for easy assertion. Comments and unknown fields are discarded.
+func readTasks(t *testing.T, path string) []ZedTask {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	data, err = hujson.Standardize(data)
+	require.NoError(t, err)
+	var tasks []ZedTask
+	require.NoError(t, json.Unmarshal(data, &tasks))
+	return tasks
+}
+
+func TestUpsertZedTasks(t *testing.T) {
+	t.Run("creates file and appends tasks when missing", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".zed", "tasks.json")
+
+		require.NoError(t, New().UpsertZedTasks(
+			WithZedTasksFile(path),
+			WithExtraTasks(
+				ZedTask{Label: "task1", Command: "cmd1"},
+				ZedTask{Label: "task2", Command: "cmd2", Args: []string{"--flag"}},
+			),
+		)(t.Context()))
+
+		tasks := readTasks(t, path)
+		require.Len(t, tasks, 2)
+		assert.Equal(t, "task1", tasks[0].Label)
+		assert.Equal(t, "task2", tasks[1].Label)
+		assert.Equal(t, []string{"--flag"}, tasks[1].Args)
+	})
+
+	t.Run("re-run refreshes command/args; preserves user fields and unknown JSON keys", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "tasks.json")
+
+		// Seed file with a task that has a user-set field and a future Zed key
+		// that is not in our ZedTask struct.
+		seed := `[{"label":"my task","command":"old","args":["old"],"reveal":"always","zed_future":42}]`
+		require.NoError(t, os.WriteFile(path, []byte(seed), 0o644))
+
+		require.NoError(t, New().UpsertZedTasks(
+			WithZedTasksFile(path),
+			WithExtraTasks(ZedTask{Label: "my task", Command: "new", Args: []string{"new"}}),
+		)(t.Context()))
+
+		tasks := readTasks(t, path)
+		require.Len(t, tasks, 1)
+		assert.Equal(t, "new", tasks[0].Command, "command must be refreshed")
+		assert.Equal(t, []string{"new"}, tasks[0].Args, "args must be refreshed")
+		assert.Equal(t, "always", tasks[0].Reveal, "user-set field must be preserved")
+
+		data, _ := os.ReadFile(path)
+		assert.Contains(t, string(data), "zed_future", "unknown key must survive")
+	})
+}
+
+func TestGenerateZedTasks(t *testing.T) {
+	skipOnWindows(t)
+
+	t.Run("generates entries for all mage targets", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "tasks.json")
+
+		require.NoError(t, New(
+			WithMageCommand("testdata/fakemage.sh"),
+		).GenerateZedTasks(
+			WithZedTasksFile(path),
+			WithExtraTasks(ZedTask{Label: "extra", Command: "extra-cmd"}),
+		)(t.Context()))
+
+		tasks := readTasks(t, path)
+		labels := make([]string, len(tasks))
+		for i, task := range tasks {
+			labels[i] = task.Label
+		}
+
+		assert.Contains(t, labels, "mage: build")
+		assert.Contains(t, labels, "mage: format")
+		assert.Contains(t, labels, "mage: lint")
+		assert.Contains(t, labels, "mage: test")
+		assert.Contains(t, labels, "extra")
+	})
+
+	t.Run("returns error when mage command is not found", func(t *testing.T) {
+		err := New(
+			WithMageCommand("/nonexistent/mage"),
+		).GenerateZedTasks(
+			WithZedTasksFile(filepath.Join(t.TempDir(), "tasks.json")),
+		)(t.Context())
+		require.Error(t, err)
+	})
+}
+
+func TestCleanupZedTasks(t *testing.T) {
+	skipOnWindows(t)
+
+	t.Run("removes stale mage tasks; keeps active and non-mage; preserves comments", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "tasks.json")
+
+		seed := `[
+  // user comment
+  {"label":"mage: build","command":"mage","args":["build"]},
+  {"label":"mage: stale","command":"mage","args":["stale"]},
+  {"label":"custom","command":"my-tool"}
+]`
+		require.NoError(t, os.WriteFile(path, []byte(seed), 0o644))
+
+		require.NoError(t, New(
+			WithMageCommand("testdata/fakemage.sh"),
+		).CleanupZedTasks(
+			WithZedTasksFile(path),
+		)(t.Context()))
+
+		tasks := readTasks(t, path)
+		labels := make([]string, len(tasks))
+		for i, task := range tasks {
+			labels[i] = task.Label
+		}
+
+		assert.Contains(t, labels, "mage: build", "active mage task must be kept")
+		assert.NotContains(t, labels, "mage: stale", "stale mage task must be removed")
+		assert.Contains(t, labels, "custom", "non-mage task must be kept")
+
+		data, _ := os.ReadFile(path)
+		assert.Contains(t, string(data), "// user comment", "comments must survive")
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/stretchr/testify v1.11.1
+	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
+	github.com/urfave/cli/v3 v3.7.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -18,6 +20,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd h1:Rf9uhF1+VJ7ZHqxrG8pJ6YacmHvVCmByDmGbAWCc/gA=
+github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd/go.mod h1:EbW0wDK/qEUYI0A5bqq0C2kF8JTQwWONmGDBbzsxxHo=
+github.com/urfave/cli/v3 v3.7.0 h1:AGSnbUyjtLiM+WJUb4dzXKldl/gL+F8OwmRDtVr6g2U=
+github.com/urfave/cli/v3 v3.7.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/magefiles/main.go
+++ b/magefiles/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aexvir/harness"
 	"github.com/aexvir/harness/commons"
+	"github.com/aexvir/harness/gen"
 )
 
 const (
@@ -29,6 +30,13 @@ func Format(ctx context.Context) error {
 		ctx,
 		commons.GoFmt(),
 		commons.GoImports(pkgName),
+	)
+}
+
+func Generate(ctx context.Context) error {
+	return h.Execute(
+		ctx,
+		gen.New().GenerateZedTasks(),
 	)
 }
 


### PR DESCRIPTION
replaces #27 and #31 

this was also generated with ai but I've used `opencode` and iterated much more on the planning phase before asking the model to generate the code

still needs thorough review to probably simplify a bit the approach, since ai codegen from experience ends up overengineering/adding noise, even if I had strong inputs during planning, and also the tests, as sometimes it tests things incorrectly or tests useless stuff